### PR TITLE
Replace /pcs with /xpan API endpoints URL.

### DIFF
--- a/src/src.py
+++ b/src/src.py
@@ -246,9 +246,9 @@ class Bpan(Utils):
         remotepath = self._format_path(remotepath)
         params = {
             'path': os.path.join(self.BASE_APP_PATH, remotepath),
-            'by': 'name',
-            'order': 'asc'}
-        res = self._request('file', 'list',
+            'order': 'name',
+            'desc': '0'}
+        res = self._request('multimedia', 'listall',
                             extra_params=params)
         if res.status_code != 200:
             raise PathError("path not exists %s" % remotepath)
@@ -316,7 +316,7 @@ class Bpan(Utils):
                         fs_id = p["fs_id"]
                         path = p["path"][len(self.BASE_APP_PATH):] + "/"
                         type_ = "Dir"
-                        mtime = p["mtime"]
+                        mtime = p.get("mtime") or p.get("local_mtime") or p.get("server_mtime")
                         category = "-"
                     else:
                         size = human_size(p["size"])
@@ -324,7 +324,7 @@ class Bpan(Utils):
                         fs_id = p["fs_id"]
                         path = p["path"][len(self.BASE_APP_PATH):]
                         type_ = "File"
-                        mtime = p["mtime"]
+                        mtime = p.get("mtime") or p.get("local_mtime") or p.get("server_mtime")
                         category = category_decode(p["category"])
                     if not path.startswith("/"):
                         path = "/" + path

--- a/src/utils.py
+++ b/src/utils.py
@@ -48,6 +48,7 @@ class Utils(object):
         self.pcsserver = get_fastest_pcs_server()
         self.pcsurl = "https://{server}/rest/2.0/pcs/".format(
             server=self.pcsserver)
+        self.xpan_url = 'https://pan.baidu.com/rest/2.0/xpan/'
 
     def _remove_empty_items(self, data):
         for k, v in data.items():
@@ -65,7 +66,7 @@ class Utils(object):
             self._remove_empty_items(params)
 
         if not url:
-            url = self.pcsurl + uri
+            url = self.xpan_url + uri
         api = url
         if data or files:
             api = '%s?%s' % (url, urlencode(params))

--- a/src/utils.py
+++ b/src/utils.py
@@ -222,7 +222,7 @@ def get_fastest_pcs_server_test():
 def get_fastest_pcs_server():
     url = 'http://pcs.baidu.com/rest/2.0/pcs/file?method=locateupload'
     ret = requests.get(url).json()
-    return ret['host']
+    return ret['server'][0]
 
 
 def parseArg():


### PR DESCRIPTION
It seems that at least some of the `/rest/2.0/pcs/` started returning 403 errors, which breaks `ls` and `download` commands. Interestingly enough `info` still works.

There're `/rest/2.0/xpan` endpoints described here: https://pan.baidu.com/union/doc/Zksg0sb73 which seems to be very similar. So this PR is about partially switching to using it.

I'm unclear as to what exactly is the history here and what's the best way forward, but at least this seems to fix most important commands. Do let me know if there's a better way to deal with it.